### PR TITLE
feat: Add `platform` to `composer.json`

### DIFF
--- a/.github/workflows/code-analysis.yaml
+++ b/.github/workflows/code-analysis.yaml
@@ -1,7 +1,9 @@
 name: Code Analysis
 
 on:
-  pull_request: null
+  pull_request:
+  pull_request_review:
+    types: [ submitted, edited ]
   push:
     branches:
       - develop

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,10 @@
       "yiisoft/yii2-composer": true
     },
     "optimize-autoloader": true,
+    "platform": {
+      "php": "8.2"
+    },
+    "platform-check": false,
     "sort-packages": true
   },
   "minimum-stability": "beta",


### PR DESCRIPTION
By default, phpstan bases the code checks it does on the current version of PHP that’s installed.

Specifying the minimum version of PHP required allows you to catch errors that use more modern versions of the PHP than the minimum version of PHP required by your project (and Craft CMS).

Adding `platform` to your `composer.json` is one way to accomplish this: https://phpstan.org/config-reference#phpversion

It’s caught many regression errors for me when porting code between versions of Craft that have lower minimum requirements, and will do the same for you going forward.

So if you use constructs that are only available in PHP 8.3 or 8.4 or later versions of PHP, it’ll catch those errors